### PR TITLE
fix: import libraries instead of require

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,8 +6,6 @@ import { filename } from 'pathe/utils';
 import ansi from 'ansi-colors';
 import { merge, readAllFiles } from './utils';
 import { VITE_PLUGIN_NAME, DEFAULT_OPTIONS } from './constants';
-import { optimize } from 'svgo';
-import sharp from 'sharp';
 
 function ViteImageOptimizer(optionsParam = {}) {
   const options = merge(optionsParam, DEFAULT_OPTIONS);
@@ -18,6 +16,7 @@ function ViteImageOptimizer(optionsParam = {}) {
   const mtimeCache = new Map();
 
   const applySVGO = async (filePath, buffer) => {
+    const optimize = (await import('svgo')).optimize
     return Buffer.from(
       optimize(buffer, {
         path: filePath,
@@ -27,6 +26,7 @@ function ViteImageOptimizer(optionsParam = {}) {
   };
 
   const applySharp = async (filePath, buffer) => {
+    const sharp = (await import('sharp')).default
     const extName = extname(filePath).replace('.', '');
     return await sharp(buffer, { animated: extName === 'gif' })
       .toFormat(extName, options[extName.toLowerCase()])

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,8 @@ import { filename } from 'pathe/utils';
 import ansi from 'ansi-colors';
 import { merge, readAllFiles } from './utils';
 import { VITE_PLUGIN_NAME, DEFAULT_OPTIONS } from './constants';
+import { optimize } from 'svgo';
+import sharp from 'sharp';
 
 function ViteImageOptimizer(optionsParam = {}) {
   const options = merge(optionsParam, DEFAULT_OPTIONS);
@@ -16,7 +18,6 @@ function ViteImageOptimizer(optionsParam = {}) {
   const mtimeCache = new Map();
 
   const applySVGO = async (filePath, buffer) => {
-    const optimize = require('svgo').optimize;
     return Buffer.from(
       optimize(buffer, {
         path: filePath,
@@ -26,7 +27,6 @@ function ViteImageOptimizer(optionsParam = {}) {
   };
 
   const applySharp = async (filePath, buffer) => {
-    const sharp = require('sharp');
     const extName = extname(filePath).replace('.', '');
     return await sharp(buffer, { animated: extName === 'gif' })
       .toFormat(extName, options[extName.toLowerCase()])

--- a/vite.config.js
+++ b/vite.config.js
@@ -17,7 +17,7 @@ export default defineConfig(({ mode }) => {
         fileName: 'index',
       },
       rollupOptions: {
-        external: ['fs', 'fs/promises'],
+        external: ['fs', 'fs/promises', 'svgo', 'sharp'],
         plugins: [
           isProd && strip(),
           visualizer({
@@ -30,6 +30,8 @@ export default defineConfig(({ mode }) => {
           globals: {
             fs: 'fs',
             'fs/promises': 'fsp',
+            'svgo': 'svgo',
+            'sharp': 'sharp',
           },
         },
       },


### PR DESCRIPTION
The require() calls trigger an exception `ReferenceError: require is not defined`
This fixes this by using import instead of require.

To be entirely honest, I'm not sure if there are potential side effects in doing this, but it seems to be a common issue, as seen at: https://github.com/vitejs/vite/issues/3409

None of the suggested solutions there worked, though.