### PR TITLE
fix(minor): Fixed bug in Windows with incorrect slashes in paths

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -184,6 +184,9 @@ function ViteImageOptimizer(optionsParam: Options = {}): Plugin {
         }
 
         if (files.length > 0) {
+          // normalize slashes in publicDir to Linux stile
+          publicDir = publicDir.replace(/[/\\]/g, '/');
+
           const handles = files.map(async (publicFilePath: string) => {
             // convert the path to the output folder
             const filePath: string = publicFilePath.replace(publicDir + sep, '');

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,7 +123,7 @@ function ViteImageOptimizer(optionsParam: Options = {}): Plugin {
       rootConfig = c;
       outputPath = c.build.outDir;
       if (typeof c.publicDir === 'string') {
-        publicDir = c.publicDir;
+        publicDir = c.publicDir.replace(/\\/g, '/');
       }
     },
     generateBundle: async (_, bundler) => {
@@ -184,9 +184,6 @@ function ViteImageOptimizer(optionsParam: Options = {}): Plugin {
         }
 
         if (files.length > 0) {
-          // normalize slashes in publicDir to Linux stile
-          publicDir = publicDir.replace(/[/\\]/g, '/');
-
           const handles = files.map(async (publicFilePath: string) => {
             // convert the path to the output folder
             const filePath: string = publicFilePath.replace(publicDir + sep, '');


### PR DESCRIPTION
### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

### Description

In Windows paths in `publicDir` is incorrect, so no images can be found to optimize.
Checked in Windows but didn't check in Linux/MacOS but should work :)

### Checks

- [ ] PR adheres to the code style of this project
- [ ] Related issues linked using `fixes #number`
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Lint and build have passed locally by running `pnpm lint && pnpm build`
- [x] Code changes have been verified in local
- [ ] Documentation added/updated if necessary

### Additional Context
