### PR TITLE
Option to disable ansi colors + fix size comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ const DEFAULT_OPTIONS = {
   include: undefined,
   includePublic: true,
   logStats: true,
+  ansiColors: true,
   svg: {
     multipass: true,
     plugins: [
@@ -154,6 +155,7 @@ const DEFAULT_OPTIONS = {
 - **[`exclude`](#exclude)**
 - **[`includePublic`](#includepublic)**
 - **[`logStats`](#logstats)**
+- **[`ansiColors`](#ansiColors)**
 - **[`svg`](#svg)**
 - **[`png`](#png)**
 - **[`jpeg`](#jpeg)**
@@ -205,6 +207,14 @@ Type: `boolean`
 Default: `true`
 
 Logs the optimization stats to terminal output with file size difference in kB, percent increase/decrease and total savings.
+
+### `ansiColors`
+
+Type: `boolean`
+
+Default: `true`
+
+Logs the optimization stats or errors with ansi colors in the terminal.
 
 ### `svg`
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 export const VITE_PLUGIN_NAME = 'vite-plugin-image-optimizer';
 export const DEFAULT_OPTIONS = {
   logStats: true,
+  ansiColors: true,
   includePublic: true,
   exclude: undefined,
   include: undefined,

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,10 @@ interface Options {
    */
   includePublic?: boolean;
   /**
+   * display logs using colors or not
+   */
+  ansiColors?: boolean;
+  /**
    * log stats to the terminal or not
    */
   logStats?: boolean;
@@ -196,10 +200,10 @@ function ViteImageOptimizer(optionsParam: Options = {}): Plugin {
         }
       }
       if (sizesMap.size > 0 && options.logStats) {
-        logOptimizationStats(rootConfig, sizesMap);
+        logOptimizationStats(rootConfig, sizesMap, options.ansiColors);
       }
       if (errorsMap.size > 0) {
-        logErrors(rootConfig, errorsMap);
+        logErrors(rootConfig, errorsMap, options.ansiColors);
       }
     },
   };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -106,15 +106,15 @@ export function logOptimizationStats(rootConfig: ResolvedConfig, sizesMap: Map<s
   const valueKeyLength: number = Math.max(...valueLengths);
 
   let totalOriginalSize: number = 0;
-  let totalKbSaved: number = 0;
+  let totalSavedSize: number = 0;
   sizesMap.forEach((value, name) => {
     const { size, oldSize, ratio, skipWrite } = value;
 
     const percentChange: string = ratio > 0 ? ansi.red(`+${ratio}%`) : ratio <= 0 ? ansi.green(`${ratio}%`) : '';
 
     const sizeText: string = skipWrite
-      ? `${ansi.yellow.bold('skipped')} ${ansi.dim(`original: ${oldSize.toFixed(2)} KB <= optimized: ${size.toFixed(2)} KB`)}`
-      : ansi.dim(`${oldSize.toFixed(2)} KB ⭢  ${size.toFixed(2)} KB`);
+      ? `${ansi.yellow.bold('skipped')} ${ansi.dim(`original: ${oldSize.toFixed(2)} kB <= optimized: ${size.toFixed(2)} kB`)}`
+      : ansi.dim(`${oldSize.toFixed(2)} kB ⭢  ${size.toFixed(2)} kB`);
 
     rootConfig.logger.info(
       decideStyle(
@@ -131,16 +131,16 @@ export function logOptimizationStats(rootConfig: ResolvedConfig, sizesMap: Map<s
 
     if (!skipWrite) {
       totalOriginalSize += oldSize;
-      totalKbSaved += oldSize - size;
+      totalSavedSize += oldSize - size;
     }
   });
 
-  if (totalKbSaved > 0) {
-    const kbText = `${totalKbSaved.toFixed(2)}KB`;
-    const mbText = `${(totalKbSaved / 1024).toFixed(2)}MB`;
-    const savingsPercent = `${Math.trunc((totalKbSaved / totalOriginalSize) * 100)}%`;
+  if (totalSavedSize > 0) {
+    const savedText = `${totalSavedSize.toFixed(2)}kB`;
+    const originalText = `${totalOriginalSize.toFixed(2)}kB`;
+    const savingsPercent = `${Math.round((totalSavedSize / totalOriginalSize) * 100)}%`;
     rootConfig.logger.info(
-      decideStyle(`\n💰 total savings = ${ansi.green(kbText)}/${ansi.green(mbText)} ≈ ${ansi.green(savingsPercent)}`, ansiColors)
+      decideStyle(`\n💰 total savings = ${ansi.green(savedText)}/${ansi.green(originalText)} ≈ ${ansi.green(savingsPercent)}`, ansiColors)
     );
   }
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.

Please make sure that the pull request is limited to one type (feat, fix, etc.) and keep it as small as possible. You can open multiple PR's instead of opening a huge one.
-->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [X] New Feature
- [ ] Documentation
- [ ] Other

### Description

This pull request add a way to disable ansi colors, causing some problems on old shell or parsing shell's output. I'm using it on a CI server and it shows the color character.
I noticed since the last update there was a new message but it showed "saved size in kB / saved size in MB" which didn't make sense to me (saved / original looks more natural)
Also changed the unit to kB instead of KB (not correct)

### Checks

- [X] PR adheres to the code style of this project
- [X] Related issues linked using `fixes #number`
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Lint and build have passed locally by running `pnpm lint && pnpm build`
- [X] Code changes have been verified in local
- [ ] Documentation added/updated if necessary

### Additional Context

<!-- Any additional information like breaking changes, dependencies added, comparisons between new and old behaviour, etc. -->
Will change the display for users using version 1.1.5
