### PR TITLE
feat: caching support

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ const DEFAULT_OPTIONS = {
     // https://sharp.pixelplumbing.com/api-output#avif
     lossless: true,
   },
+  cache: false,
+  cacheLocation: undefined,
 };
 ```
 
@@ -163,6 +165,8 @@ const DEFAULT_OPTIONS = {
 - **[`gif`](#gif)**
 - **[`webp`](#webp)**
 - **[`avif`](#webp)**
+- **[`cache`](#cache)**
+- **[`cacheLocation`](#cache)**
 
 ### `test`
 
@@ -341,6 +345,22 @@ Default:
 ```
 
 Config object to pass to Sharp.js for assets with `avif` extension
+
+### `cache`
+
+Type: `boolean`
+
+Default: `false`
+
+Cache assets in `cacheLocation`. When enabled, reads and writes asset files with their hash suffix from the specified path.
+
+### `cacheLocation`
+
+Type: `String`
+
+Default: `undefined`
+
+Path to the cache directory. Can be used with GitHub Actions and other build servers that support cache directories to speed up consecutive builds.
 
 ## License
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -59,4 +59,6 @@ export const DEFAULT_OPTIONS = {
     // https://sharp.pixelplumbing.com/api-output#avif
     lossless: true,
   },
+  cache: false,
+  cacheLocation: undefined,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -174,6 +174,12 @@ function ViteImageOptimizer(optionsParam: Options = {}): Plugin {
     }, []);
   };
 
+  const ensureCacheDirectoryExists = async function () {
+    if (options.cache === true && !fs.existsSync(options.cacheLocation)) {
+      await fsp.mkdir(options.cacheLocation);
+    }
+  };
+
   return {
     name: VITE_PLUGIN_NAME,
     enforce: 'post',
@@ -190,9 +196,7 @@ function ViteImageOptimizer(optionsParam: Options = {}): Plugin {
       const files: string[] = getFilesToProcess(allFiles, path => (bundler[path] as any).name);
 
       if (files.length > 0) {
-        if (options.cache === true && !fs.existsSync(options.cacheLocation)) {
-          await fsp.mkdir(options.cacheLocation);
-        }
+        await ensureCacheDirectoryExists();
 
         const handles = files.map(async (filePath: string) => {
           const source = (bundler[filePath] as any).source;
@@ -212,6 +216,8 @@ function ViteImageOptimizer(optionsParam: Options = {}): Plugin {
         const files: string[] = getFilesToProcess(allFiles, path => filename(path) + extname(path));
 
         if (files.length > 0) {
+          await ensureCacheDirectoryExists();
+
           const handles = files.map(async (publicFilePath: string) => {
             // convert the path to the output folder
             const filePath: string = publicFilePath.replace(publicDir + sep, '');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,7 @@ interface Sizes {
   oldSize: number;
   ratio: number;
   skipWrite: boolean;
+  isCached: boolean;
 }
 
 /* type utils */
@@ -108,12 +109,14 @@ export function logOptimizationStats(rootConfig: ResolvedConfig, sizesMap: Map<s
   let totalOriginalSize: number = 0;
   let totalSavedSize: number = 0;
   sizesMap.forEach((value, name) => {
-    const { size, oldSize, ratio, skipWrite } = value;
+    const { size, oldSize, ratio, skipWrite, isCached } = value;
 
     const percentChange: string = ratio > 0 ? ansi.red(`+${ratio}%`) : ratio <= 0 ? ansi.green(`${ratio}%`) : '';
 
     const sizeText: string = skipWrite
       ? `${ansi.yellow.bold('skipped')} ${ansi.dim(`original: ${oldSize.toFixed(2)} kB <= optimized: ${size.toFixed(2)} kB`)}`
+      : isCached
+      ? `${ansi.yellow.bold('cached')} ${ansi.dim(`original: ${oldSize.toFixed(2)} kB; cached: ${size.toFixed(2)} kB`)}`
       : ansi.dim(`${oldSize.toFixed(2)} kB ⭢  ${size.toFixed(2)} kB`);
 
     rootConfig.logger.info(


### PR DESCRIPTION
### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [x] Documentation
- [ ] Other

### Description

Fixes #24

As discussed in #24, this feature adds a caching mechanism where `vite-plugin-image-optimizer` checks a configured cache directory for the existence of an optimized asset. If the asset exists, this cached version is used and optimization is skipped. Optimized assets are written to the cache directory so they can be used on the next run.

This mechanism speeds up consecutive builds on build systems such as GitHub Actions or JetBrains TeamCity when the asset cache is reused across builds.

Cache is disabled by default, and considered opt-in.

### Checks

- [x] PR adheres to the code style of this project
- [x] Related issues linked using `fixes #number`
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Lint and build have passed locally by running `pnpm lint && pnpm build`
- [x] Code changes have been verified in local
- [x] Documentation added/updated if necessary