### PR TITLE
fix: Use root path when building full destination

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -221,7 +221,7 @@ function ViteImageOptimizer(optionsParam: Options = {}): Plugin {
           const handles = files.map(async (publicFilePath: string) => {
             // convert the path to the output folder
             const filePath: string = publicFilePath.replace(publicDir + sep, '');
-            const fullFilePath: string = join(outputPath, filePath);
+            const fullFilePath: string = join(rootConfig.root, outputPath, filePath);
 
             if (fs.existsSync(fullFilePath) === false) return;
 


### PR DESCRIPTION
### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

### Description

Previously this plugin would not do anything when you put your project's site files under a folder. See the `root` [shared option]. With this change, the user now can have source files in a folder that is not at the project root.

This may also fix FatehAK/vite-plugin-image-optimizer#30, since I am also using Vite 5.x.

[shared option]: https://vitejs.dev/config/shared-options.html

### Checks

- [X] PR adheres to the code style of this project
- [X] Related issues linked using `fixes #number`
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Lint and build have passed locally by running `pnpm lint && pnpm build`
- [X] Code changes have been verified in local
- [X] Documentation added/updated if necessary

### Additional Context

