### PR TITLE
fix: issue with absolute output paths

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import type { PngOptions, JpegOptions, TiffOptions, GifOptions, WebpOptions, Avi
 import type { Config as SVGOConfig } from 'svgo';
 import fs from 'fs';
 import fsp from 'fs/promises';
-import { dirname, extname, join, sep } from 'pathe';
+import { dirname, extname, join, resolve, sep } from 'pathe';
 import { filename } from 'pathe/utils';
 import { merge, readAllFiles, areFilesMatching, logErrors, logOptimizationStats } from './utils';
 import { VITE_PLUGIN_NAME, DEFAULT_OPTIONS } from './constants';
@@ -221,7 +221,7 @@ function ViteImageOptimizer(optionsParam: Options = {}): Plugin {
           const handles = files.map(async (publicFilePath: string) => {
             // convert the path to the output folder
             const filePath: string = publicFilePath.replace(publicDir + sep, '');
-            const fullFilePath: string = join(rootConfig.root, outputPath, filePath);
+            const fullFilePath: string = resolve(rootConfig.root, outputPath, filePath);
 
             if (fs.existsSync(fullFilePath) === false) return;
 


### PR DESCRIPTION
maybe it fix also similar issue: https://github.com/FatehAK/vite-plugin-image-optimizer/issues/36

<!--
Thanks for opening a PR! Your contribution is much appreciated.

Please make sure that the pull request is limited to one type (feat, fix, etc.) and keep it as small as possible. You can open multiple PR's instead of opening a huge one.
-->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation
- [ ] Other

### Description

Use `resolve` than `join` to compute `fullFilePath` to handle `outputPath` correctly if set to an absolute path.
Resolve is checking if a parameter is an absolute path and ignore preceding paths.
Join always concatenate all path parameters which add an base path to the outputPath - that creates a non-existing path if outputPath is already absolute.

<!-- Add a brief description of the pull request -->

### Checks

- [X] PR adheres to the code style of this project
- [ ] Related issues linked using `fixes #number`
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Lint and build have passed locally by running `pnpm lint && pnpm build`
- [X] Code changes have been verified in local
- [ ] Documentation added/updated if necessary

### Additional Context

I use vite with absolute output paths to generate builds.
<!-- Any additional information like breaking changes, dependencies added, comparisons between new and old behaviour, etc. -->
