### PR TITLE
feat: respect NO_COLOR environment variable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,9 @@ interface Options {
 
 function ViteImageOptimizer(optionsParam: Options = {}): Plugin {
   const options: Options = merge(optionsParam, DEFAULT_OPTIONS);
+  if (process.env.NO_COLOR === '1') {
+    options.ansiColors = false;
+  }
 
   let outputPath: string;
   let publicDir: string;


### PR DESCRIPTION
## Summary
Follows Vite's behavior to disable ANSI colored output when the NO_COLOR environment variable is set.

## Problem
Closes #57
The plugin unconditionally generates ANSI colors, which can cause problematic logs when piped into files or systems that do not support ANSI sequences.

## Solution
Checks `process.env.NO_COLOR === '1'` and internally sets `ansiColors = false` during plugin initialization.

## Testing
- Tested locally
- Build succeeds
- Prettier/ESLint passes